### PR TITLE
Fix bug: 401 unauthorized error when creating new user.

### DIFF
--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -1,9 +1,27 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class GqlAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super(); 
+  }
+
+  canActivate(context: ExecutionContext) {
+    const skipAuth = this.reflector.get<boolean>(
+      'skipAuth',
+      context.getHandler()
+    );
+
+    if (skipAuth) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+
   getRequest(context: ExecutionContext) {
     const ctx = GqlExecutionContext.create(context);
     return ctx.getContext().req;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 // Imports the NestFactory class: core factory class for creating instances of a NestJS application.
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 // Import the NestFactory class from the NestJS core package.  Including other modules, providers, controllers, etc.
 import { AppModule } from './app.module';
+import { GqlAuthGuard } from './common/guards/auth.guard';
 
 // Define an asynchronous bootstrap function to set up the application.
 async function bootstrap() {
@@ -9,6 +10,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // Enable Cross-Origin Resource Sharing (CORS) for the application.
   app.enableCors();
+  // Global guard
+  const reflector = app.get(Reflector);
+  app.useGlobalGuards(new GqlAuthGuard(reflector));
   // Tell the application to listen for incoming requests on port 3000.
   await app.listen(3000);
 }

--- a/src/modules/auth/skip-auth.decorator.ts
+++ b/src/modules/auth/skip-auth.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SkipAuth = () => SetMetadata('skipAuth', true);

--- a/src/modules/user/user.resolver.ts
+++ b/src/modules/user/user.resolver.ts
@@ -4,10 +4,9 @@ import { CreateUserInput } from './dto/new-user.input';
 import { UserType } from './dto/user.type';
 import { UserService } from './user.service';
 import { UpdateUserInput } from './dto/update-user.input';
-import { GqlAuthGuard } from '@/common/guards/auth.guard';
+import { SkipAuth } from '../auth/skip-auth.decorator';
 
 @Resolver()
-@UseGuards(GqlAuthGuard)
 export class UserResolver {
   constructor(private readonly userService: UserService) {}
 
@@ -32,6 +31,7 @@ export class UserResolver {
     return await this.userService.find(id);
   }
 
+  @SkipAuth()
   @Mutation(() => Boolean, { description: 'Create new user' })
   async createUser(@Args('input') input: CreateUserInput): Promise<boolean> {
     return await this.userService.create(input);


### PR DESCRIPTION
Solution: Skipped authentication for user creation. Reason: Since there is no credential to verify against before the user is actually created, authentication for user creation should be skipped. Method:
- Enabled global authentication.
- Created SkipAuth() decorator.
- Use Reflector to find "skipAuth" metadata and skip authentication when found.
- Wrap user creationmethod with the decorator. Ref: https://docs.nestjs.com/security/authentication#enable-authentication-globally